### PR TITLE
Fixed line 18 in examples/ReadAltitude/ReadAltitude.ino

### DIFF
--- a/examples/ReadAltitude/ReadAltitude.ino
+++ b/examples/ReadAltitude/ReadAltitude.ino
@@ -15,7 +15,7 @@ void setup()
 void loop()
 {
   Serial.print("Altitude: ");
-  Serial.print(altitude);
+  Serial.print(bmp180.readAltitude());
   Serial.println(" m");
 
   delay(2000);


### PR DESCRIPTION
Fixed line 18 in examples/ReadAltitude/ReadAltitude.ino being Serial.print(altitude); instead of Serial.print(bmp180.readAltitude());